### PR TITLE
VRSUS-10 Implement primary metadata display

### DIFF
--- a/src/components/MetadataSection.vue
+++ b/src/components/MetadataSection.vue
@@ -1,0 +1,30 @@
+<template>
+  <div class="metadata-block">
+    <h4 class="metadata-block__title">Item Overview</h4>
+
+    <div v-for="field in fields" :key="field[0]">
+      <dl class="metadata-block__group">
+        <dt class="metadata-block__label-key">
+          <!-- KEY -->
+          {{ field[0] }}
+        </dt>
+        <!-- VALUE -->
+        <dd
+          class="metadata-block__label-value metadata-block__label-value--ursus"
+        >
+          {{ field[1] }}
+        </dd>
+      </dl>
+    </div>
+    <hr class="divider divider--ursus" />
+  </div>
+</template>
+
+<script>
+import { Component, Prop, Vue } from "vue-property-decorator";
+
+export default {
+  name: "MetadataSection",
+  props: ["fields"]
+};
+</script>

--- a/src/services/APIService.js
+++ b/src/services/APIService.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 const apiClient = axios.create({
-  baseURL: `https://digital.library.ucla.edu`,
+  baseURL: `https://ursus-dev.library.ucla.edu`,
   withCredentials: false, // This is the default
   headers: {
     Accept: "application/json",

--- a/src/views/WorkShow.vue
+++ b/src/views/WorkShow.vue
@@ -1,14 +1,17 @@
 <template>
   <div>
     <h1>
-      Work show Page for {{ data.attributes.title_tesim.attributes.value }}
+      Work Show Page
+      Work show Page for {{ data.attributes }}
     </h1>
+    <!--
     <table>
       <tr v-for="record in data.attributes" :key="record.id">
         <td>{{ record.attributes.label }}</td>
         <td>{{ record.attributes.value }}</td>
       </tr>
     </table>
+    -->
   </div>
 </template>
 
@@ -27,6 +30,7 @@ export default {
     APIService.getItem(this.$route.params.ark)
       .then(response => {
         this.data = response.data.data;
+        console.log('We are looking for a response')
       })
       .catch(error => {
         console.log("Error:" + error.response);

--- a/src/views/WorkShow.vue
+++ b/src/views/WorkShow.vue
@@ -1,36 +1,44 @@
 <template>
   <div>
     <h1>
-      Work Show Page
-      Work show Page for {{ data.attributes }}
+      Work Show Page VUE
+      <!-- Work show Page for {{ data.attributes }} -->
     </h1>
-    <!--
+    <MetadataSection :fields="primaryMetadata" />
+
     <table>
       <tr v-for="record in data.attributes" :key="record.id">
         <td>{{ record.attributes.label }}</td>
         <td>{{ record.attributes.value }}</td>
       </tr>
     </table>
-    -->
   </div>
 </template>
 
 <script>
 /* eslint-disable */
 import APIService from "@/services/APIService.js";
-
+import MetadataSection from "@/components/MetadataSection.vue";
 export default {
   name: "WorkShow",
+  components: {
+    MetadataSection
+  },
   data() {
     return {
       data: {}
     };
   },
+  computed: {
+    primaryMetadata: function() {
+      console.log("Hi"); return [ ['key1', 'value1'] ]
+    }
+  },
   created() {
     APIService.getItem(this.$route.params.ark)
       .then(response => {
         this.data = response.data.data;
-        console.log('We are looking for a response')
+        console.log("We are looking for a response");
       })
       .catch(error => {
         console.log("Error:" + error.response);


### PR DESCRIPTION
Connected to [VRSUS-10](https://jira.library.ucla.edu/browse/VRSUS-10)

### VRSUS-10 Implement primary metadata display

#### Create a Metadata component that displays
+ a header
and loops through the fields to output all the
+ metadata keys
+ metadata values

### We changed api url
From:  
baseURL: `https://digital.library.ucla.edu`  
To:  
baseURL: `https://ursus-dev.library.ucla.edu`

<img width="1116" alt="Screen Shot 2020-07-31 at 5 09 16 PM" src="https://user-images.githubusercontent.com/751697/89089228-208acb00-d351-11ea-91fc-6d464095006b.png">

---

### Changes to be committed:
+ new file:   src/components/MetadataSection.vue
+ modified:   src/views/WorkShow.vue

---

#### Authors:
+ Parinita Mulak <pghorpade@library.ucla.edu>
+ Ashton Prigge <aprigge@library.ucla.edu>
+ Jen Diamond <thejendiamond@gmail.com>
+ Andy Wallace <aw@andrewbenedictwallace.com>

Date:  Fri Jul 31 15:18:18 2020 -0700

On branch VRSUS-10/primary_metadata

